### PR TITLE
use semicolon for comments

### DIFF
--- a/settings/language-actr.cson
+++ b/settings/language-actr.cson
@@ -1,0 +1,7 @@
+'.source.actr':
+  editor:
+    commentStart: '; '
+    tabLength: 2
+  # FIXME Following does not work!
+  "bracket-matcher":
+    autocompleteBrackets: false


### PR DESCRIPTION
Thanks for your work on this package. I found that when I wanted to comment out a section of code it was using /* */ for comments. I adapted this file from https://github.com/enriquefernandez/language-lisp to use semicolons if you want to include it. I don't really know what I'm doing, but it works for me.